### PR TITLE
Move validators translations

### DIFF
--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -33,7 +33,6 @@ Create a new job: Créer un job
 Jobs list: Liste des jobs
 Execution history: Historique d'exécution
 Job detail: Détail d'un job
-Invalid schedule format (should be cron-compliant): Format de la fréquence invalide (doit être au format cron)
 Runner: Runner
 Jobs: Jobs
 Executions: Exécutions

--- a/Resources/translations/validators.fr.yml
+++ b/Resources/translations/validators.fr.yml
@@ -1,0 +1,1 @@
+Invalid schedule format (should be cron-compliant): Format de la fréquence invalide (doit être au format cron)


### PR DESCRIPTION
The translation was missing as it should have been in the `validators` domain.