### PR TITLE
Remove @JoinColumn

### DIFF
--- a/Entity/Execution.php
+++ b/Entity/Execution.php
@@ -26,7 +26,6 @@ class Execution
 
     /**
      * @ORM\ManyToOne(targetEntity="Autobus\Bundle\BusBundle\Entity\Job", inversedBy="executions")
-     * @ORM\JoinColumn(name="service", referencedColumnName="id")
      */
     private $job;
 

--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -93,7 +93,6 @@ abstract class Job
 
     /**
      * @ORM\ManyToOne(targetEntity="Autobus\Bundle\BusBundle\Entity\JobGroup", inversedBy="jobs")
-     * @ORM\JoinColumn(name="group_id", referencedColumnName="id")
      */
     private $group;
 


### PR DESCRIPTION
From: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/annotations-reference.html#joincolumn

>  This annotation is not required. If it is not specified the attributes name and referencedColumnName are inferred from the table and primary key names.