### PR TITLE
Remove unnecessary annotations

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -13,8 +13,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @ORM\Entity(repositoryClass="Autobus\Bundle\BusBundle\Repository\JobRepository")
  * @ORM\InheritanceType("JOINED")
- * @ORM\DiscriminatorColumn(name="discr", type="string")
- * @ORM\DiscriminatorMap({"web_job" = "WebJob", "queue_job" = "QueueJob", "cron_job" = "CronJob"})
  * @ORM\HasLifecycleCallbacks()
  */
 abstract class Job


### PR DESCRIPTION
The `DiscriminatorColumn` column will be `dtype`.
The `dtype` will be generated from the class name (`webjob` for `WebJob` class).